### PR TITLE
use https rather than ssh;

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ NeoPI is platform independent and can be run on any system with Python 2.6 or gr
 #How to use it
 NeoPI is platform independent and will run on both Linux and Windows.  To start using NeoPI first checkout the code from our github repository
 
-	git clone ssh://git@github.com:Neohapsis/NeoPI.git
+	git clone https://github.com/Neohapsis/NeoPI.git
 
 The small NeoPI script is now in your local directory.  We are going to go though a few examples on Linux and then switch over to Windows.  
 


### PR DESCRIPTION
  ssh will fail for people who don't have key set up with github

<pre>
git clone git@github.com:Neohapsis/NeoPI.git
Cloning into 'NeoPI'...
The authenticity of host 'github.com (192.30.252.130)' can't be established.
RSA key fingerprint is 16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,192.30.252.130' (RSA) to the list of known hosts.
Permission denied (publickey).
fatal: The remote end hung up unexpectedly
</pre>
