### PR TITLE
Handling Case of Bad Symlinks

### DIFF
--- a/neopi.py
+++ b/neopi.py
@@ -306,13 +306,17 @@ class SearchFile:
        for root, dirs, files in os.walk(args[0]):
            for file in files:
                filename = os.path.join(root, file)
-               if (valid_regex.search(file) and os.path.getsize(filename) > SMALLEST):
+               try:
+                   if (valid_regex.search(file) and os.path.getsize(filename) > SMALLEST):
                    try:
                        data = open(root + "/" + file, 'rb').read()
                    except:
                        data = False
                        print "Could not read file :: %s/%s" % (root, file)
                    yield data, filename
+                except:
+                    pass
+               
 
 if __name__ == "__main__":
    """Parse all the options"""


### PR DESCRIPTION
Handling cases of bad _symlinks_ where the size of the file cannot be retrieved and so raises an uncaught exception. 

It is also linked to this [issue](https://github.com/Neohapsis/NeoPI/issues/8)
